### PR TITLE
Add workspace path variable expansion to settings

### DIFF
--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -6,16 +6,33 @@ import * as vscode from 'vscode';
 import * as os from 'os';
 import * as path from 'path';
 
+function substitute_workplace_folder(setting: string): string {
+  let workplace_folder: string = "";
+
+  for (const possible_path of [vscode.workspace.rootPath, vscode.window.activeTextEditor]) {
+    if (possible_path !== undefined) {
+      workplace_folder = possible_path;
+      break;
+    }
+  }
+
+  for (const workspace_varible of ['workspaceRoot', 'workspaceFolder']) {
+    setting = setting.replace('${' + workspace_varible + '}', workplace_folder);
+  }
+  return setting;
+}
+
 function absolutePath(userDefinedPath: string) {
-  return userDefinedPath.includes('~') ?
-      path.normalize(userDefinedPath.replace(/^~/, os.homedir() + '/')) :
-      userDefinedPath;
+
+  if (userDefinedPath.includes('~'))
+    return path.normalize(userDefinedPath.replace(/^~/, os.homedir() + '/'));
+  return path.normalize(substitute_workplace_folder(userDefinedPath))
 }
 
 export function prodSettings(): Settings {
   return {
     gnPath: () =>
-        absolutePath(vscode.workspace.getConfiguration().get('gnformat.path')),
+        absolutePath(vscode.workspace.getConfiguration('gnformat').get('path')),
   };
 }
 


### PR DESCRIPTION
This allows the use of settings that look like this. 

```
# In settings.json
"gnformat.path": "~/bin/gn",
"gnformat.path": "${workspaceRoot}/bin/gn",
"gnformat.path": "${workspaceFolder}/bin/gn",
"gnformat.path": "/opt/bin/bin/gn",
```